### PR TITLE
apt install している chrome と ChromeDriver の version を合わせる

### DIFF
--- a/java11-browser-awscli-library/Dockerfile
+++ b/java11-browser-awscli-library/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_88) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-awscli-library/Dockerfile
+++ b/java8-browser-awscli-library/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_88) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-library/Dockerfile
+++ b/java8-browser-library/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
       gnupg
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_88) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip chromedriver_linux64.zip \


### PR DESCRIPTION
apt install している chrome が 88.0.4324.96-1 になっており、
ChromeDriver の version(https://chromedriver.storage.googleapis.com/LATEST_RELEASE) が 87.0.4280.88 を指し示している。
(この為、Selenium の起動に失敗している)

ChromeDriver の version を合わせるように LATEST_RELEASE_88 を指定(現在 88.0.4324.27 を指している)
