### PR TITLE
LATEST_RELEASE_88 -> LATEST_RELEASE に変更

### DIFF
--- a/java11-browser-awscli-library/Dockerfile
+++ b/java11-browser-awscli-library/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_88) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-awscli-library/Dockerfile
+++ b/java8-browser-awscli-library/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_88) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-library/Dockerfile
+++ b/java8-browser-library/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
       gnupg
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_88) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip chromedriver_linux64.zip \


### PR DESCRIPTION
https://chromedriver.storage.googleapis.com/LATEST_RELEASE で 88  系を返すようになった為、
https://github.com/prismatix-jp/openjdk-with-git/pull/12 の対応を戻す。

apt install の log

```
Get:1 http://dl.google.com/linux/chrome/deb stable/main amd64 google-chrome-stable amd64 88.0.4324.96-1 [72.8 MB]
```

ChromeDriver の install 時の log

```
Step 3/3 : RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE)  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}"  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip  && unzip -q chromedriver_linux64.zip  && rm chromedriver_linux64.zip  && mv -f ./chromedriver /usr/bin/chromedriver
 ---> Running in c2f51fd59bcc
CHROME_DRIVER_VERSION: 88.0.4324.96
```