### PR TITLE
apt install している chrome と ChromeDriver の version を合わせる(89)

### DIFF
--- a/java11-browser-awscli-library/Dockerfile
+++ b/java11-browser-awscli-library/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_89) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-awscli-library/Dockerfile
+++ b/java8-browser-awscli-library/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_89) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-library/Dockerfile
+++ b/java8-browser-library/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
       gnupg
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE) \
+RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_89) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip chromedriver_linux64.zip \


### PR DESCRIPTION
apt install している chrome が 89.0.4389.128-1 になっており、
ChromeDriver の version(https://chromedriver.storage.googleapis.com/LATEST_RELEASE) が 90.0.4430.24 を指し示している。
(この為、Selenium を使用したテストで失敗している)

ChromeDriver の version を合わせるように LATEST_RELEASE_89 を指定(現在 89.0.4389.23 を指している)