### PR TITLE
Chromeの最新メジャーバージョンを元にChromeDriverの最新バージョンを取得するよう修正する

### DIFF
--- a/java11-browser-awscli-library/Dockerfile
+++ b/java11-browser-awscli-library/Dockerfile
@@ -21,7 +21,10 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_89) \
+RUN CHROME_LATEST_VERSION=$(curl -sS omahaproxy.appspot.com/linux?channel=stable) \
+ && echo "CHROME_LATEST_VERSION: ${CHROME_LATEST_VERSION}" \
+ && CHROME_LATEST_MAJOR_VERSION=$(echo $CHROME_LATEST_VERSION | cut -d . -f 1) \
+ && CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_LATEST_MAJOR_VERSION) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-awscli-library/Dockerfile
+++ b/java8-browser-awscli-library/Dockerfile
@@ -21,7 +21,10 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_89) \
+RUN CHROME_LATEST_VERSION=$(curl -sS omahaproxy.appspot.com/linux?channel=stable) \
+ && echo "CHROME_LATEST_VERSION: ${CHROME_LATEST_VERSION}" \
+ && CHROME_LATEST_MAJOR_VERSION=$(echo $CHROME_LATEST_VERSION | cut -d . -f 1) \
+ && CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_LATEST_MAJOR_VERSION) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip -q chromedriver_linux64.zip \

--- a/java8-browser-library/Dockerfile
+++ b/java8-browser-library/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update \
       gnupg
 
 # chrome driver のインストール
-RUN CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_89) \
+RUN CHROME_LATEST_VERSION=$(curl -sS omahaproxy.appspot.com/linux?channel=stable) \
+ && echo "CHROME_LATEST_VERSION: ${CHROME_LATEST_VERSION}" \
+ && CHROME_LATEST_MAJOR_VERSION=$(echo $CHROME_LATEST_VERSION | cut -d . -f 1) \
+ && CHROME_DRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_LATEST_MAJOR_VERSION) \
  && echo "CHROME_DRIVER_VERSION: ${CHROME_DRIVER_VERSION}" \
  && curl -sS http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -o chromedriver_linux64.zip \
  && unzip chromedriver_linux64.zip \


### PR DESCRIPTION
see #14 #15

- https://omahaproxy.appspot.com/ からChromeの最新stableバージョンを取得
    - https://omahaproxy.appspot.com/about  
      > This application is supported by the Chromium team, as a tool to track current releases and release history.
- Chromeの最新バージョンからメジャーバージョンを切り出し
- ChromeDriverのメジャーバージョンにChromeのメジャーバージョンを指定して最新バージョンを取得する